### PR TITLE
Use binary releases

### DIFF
--- a/.github/workflows/release-version.yml
+++ b/.github/workflows/release-version.yml
@@ -1,29 +1,36 @@
-name: Release New Action Version
+name: Release New Bot Version
+
 on:
   workflow_dispatch:
   push:
     branches:
-      - "main"
+      - main
+
+permissions:
+  contents: write
+
 jobs:
   release-action:
     name: Release new version
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
 
       - name: Bump Version
+        id: bump-version
         uses: patriotsoftware/semver-bump-action@v1
 
-      - name: Build
+      - name: Build Binary
         uses: actions/setup-go@v5
         with:
           go-version: '^1.23'
-      - run: go build -o /app
+      - run: go build -o slack-bot
 
       - name: Release
         uses: softprops/action-gh-release@v2
-        if: startsWith(github.ref, 'refs/tags/')
         with:
-          files: app
+          make_latest: true
+          tag_name: ${{ steps.bump-version.outputs.resulting-semver-tag }}
+          files: slack-bot

--- a/action.yml
+++ b/action.yml
@@ -31,12 +31,30 @@ inputs:
   fallback-destination:
     description: "Destination to use if any of the destinations fail."
     required: false
-
 outputs:
   validate-output:
     description: "This is used to validate success of the action."
 runs:
-  using: docker
-  image: Dockerfile
-
-    
+  using: composite
+  steps:
+  - name: Download slack-bot release
+    uses: robinraju/release-downloader@v1
+    with:
+      repository: patriotsoftware/slack-bot-action
+      latest: true
+      fileName: slack-bot
+  - name: Run slack-bot
+    shell: bash
+    env:
+      INPUT_DESTINATION: ${{ inputs.destination }}
+      INPUT_MESSAGE: ${{ inputs.message }}
+      INPUT_SLACK-TOKEN: ${{ inputs.slack-token }}
+      INPUT_RESULTS: ${{ inputs.results }}
+      INPUT_GITHUB_TOKEN: ${{ inputs.github_token }}
+      INPUT_GITHUB_REPOSITORY: ${{ inputs.github_repository }}
+      INPUT_GITHUB_SHA: ${{ inputs.github_sha }}
+      INPUT_REMOVE-BRANCH-PREFIX: ${{ inputs.remove-branch-prefix }}
+      INPUT_FALLBACK-DESTINATION: ${{ inputs.fallback-destination }}
+    run: |
+      chmod +x slack-bot
+      ./slack-bot


### PR DESCRIPTION
This PR removes the docker dependency. Instead, we will publish a prebuilt binary as a github release. The action, when called by other workflows, will download the latest binary release and execute `slack-bot`. Docker is no longer needed to build or run this action.